### PR TITLE
[WIP] Support `do {...};` for breakable/restartable blocks

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,0 +1,42 @@
+## `do` without `while` ##
+
+`do` statements can omit the *while* clause, in which case this:
+
+```d
+do {...};
+```
+
+is equivalent to this:
+
+```d
+do {
+    ...
+    break;
+} while(true);
+```
+
+This gives us a lightweight syntax supporting both *breakable* and
+*restartable* blocks, where the loop is broken or restarted between two
+statements within the block.
+
+Examples:
+
+```d
+do {
+    ...
+    if (skip) break; // early exit
+    ...
+};
+```
+
+```d
+// Infinite loop
+do {
+    ...
+    continue;
+};
+```
+
+Note that `do {...}; while (cond);` (which has an unintentional semi-colon
+before `while`) will not compile as the *while* statement has an empty loop
+statement.

--- a/src/volt/ir/util.d
+++ b/src/volt/ir/util.d
@@ -1903,3 +1903,10 @@ ir.GotoStatement buildGotoCase(Location loc)
 	gs.isCase = true;
 	return gs;
 }
+
+ir.BreakStatement buildBreak(Location loc)
+{
+	auto bs = new ir.BreakStatement();
+	bs.location = loc;
+	return bs;
+}

--- a/src/volt/parser/statements.d
+++ b/src/volt/parser/statements.d
@@ -562,16 +562,10 @@ ParseStatus parseDoStatement(ParserStream ps, out ir.DoStatement d)
 	}
 	if (hasBrace && ps == TokenType.Semicolon)
 	{
-		// For now, require loop body to explicitly end.
-		// Really we should just insert a break statement.
-		import volt.ir.base;
-		auto nt = d.block.statements[$-1].nodeType;
-		if (nt != NodeType.BreakStatement && nt != NodeType.ContinueStatement)
-			return parseExpected(ps, ps.peek.location, d,
-				"'break' or 'continue' as final statement in do statement block");
 		// do {...}; defaults to while(true) so continue works
-		import volt.ir.util;
 		d.condition = buildConstantBool(ps.peek.location, true);
+		d.block.statements ~= buildBreak(ps.peek.location);
+		ps.get();
 		return Succeeded;
 	}
 	if (ps != TokenType.While) {

--- a/test/do.volt
+++ b/test/do.volt
@@ -1,0 +1,22 @@
+//T compiles:yes
+//T has-passed:yes
+module doblock;
+
+
+void main()
+{
+	auto i = 0;
+	do
+	{
+		i++;
+		if (i == 1)
+			continue;
+		break; // FIXME: should be implicit
+	};
+	do
+	{
+		break;
+		continue;
+	};
+	assert(i == 2);
+}

--- a/test/do.volt
+++ b/test/do.volt
@@ -11,7 +11,6 @@ void main()
 		i++;
 		if (i == 1)
 			continue;
-		break; // FIXME: should be implicit
 	};
 	do
 	{


### PR DESCRIPTION
For rationale, please see `changes.md`.

Warning: I'm in the process of building LLVM on Windows, so haven't linked Volta yet but my changes do at least compile.

* I'm not sure what `//T has-passed:` means.
* How do I run the test suite?
* ~~I'm not sure how to append a break statement into a block statement, so for now break/continue are required at the end of the block~~.