### PR TITLE
Strict override

### DIFF
--- a/rt/test/errors/035/test.volt
+++ b/rt/test/errors/035/test.volt
@@ -1,0 +1,20 @@
+//T macro:expect-failure
+//T check:no matching
+module test;
+
+class A {
+	bool func() {
+		return true;
+	}
+}
+
+class B : A {
+	override void func() {
+	}
+}
+
+int main() {
+	auto b = new B();
+	b.func();
+	return 0;
+}

--- a/src/volt/semantic/classresolver.d
+++ b/src/volt/semantic/classresolver.d
@@ -480,7 +480,7 @@ void appendPotentialOverrideFunctions(ir.Function func, ir.Function considerFunc
 		return;
 	}
 
-	if (func.name == considerFunction.name) {
+	if (func.name == considerFunction.name && typesEqual(func.type, considerFunction.type)) {
 		if (func.access != considerFunction.access) {
 			throw makeOverriddenFunctionsAccessMismatch(func, considerFunction);
 		}


### PR DESCRIPTION
Prior logic only cared about names and then verified the call. That seems like a Bad Thing. This patch won't add any function for consideration for override unless the function type matches exactly. This doesn't seem to break anything, but it is a behavioural change, hence PR.