### PR TITLE
MULTIBIND

### DIFF
--- a/rt/test/statement/import/045/test.volt
+++ b/rt/test/statement/import/045/test.volt
@@ -1,0 +1,9 @@
+//T macro:import
+module test;
+
+import watt = [m1, m13];
+
+fn main() i32
+{
+    return watt.exportedVar - (watt.retval + 1);
+}

--- a/rt/test/statement/import/046/test.volt
+++ b/rt/test/statement/import/046/test.volt
@@ -1,0 +1,9 @@
+//T macro:import
+module test;
+
+import watt = [m1, m2];
+
+fn main() i32
+{
+    return 0;  // Error should occur on lookup.
+}

--- a/rt/test/statement/import/047/test.volt
+++ b/rt/test/statement/import/047/test.volt
@@ -1,0 +1,10 @@
+//T macro:importfail
+//T check:multiple imports contain
+module test;
+
+import watt = [m1, m2];
+
+fn main() i32
+{
+    return watt.exportedVar;
+}

--- a/rt/test/statement/import/048/test.volt
+++ b/rt/test/statement/import/048/test.volt
@@ -1,0 +1,9 @@
+//T macro:import
+module test;
+
+import watt = [m1, m14];
+
+fn main() i32
+{
+    return watt.uniqueVar - 2;  // Error should be on failed lookup, not mere presence of collisions.
+}

--- a/rt/test/statement/import/049/test.volt
+++ b/rt/test/statement/import/049/test.volt
@@ -1,0 +1,10 @@
+//T macro:importfail
+//T check:may only be used in bind imports
+module test;
+
+import [m1, m14];
+
+fn main() i32
+{
+    return uniqueVar - 2;
+}

--- a/rt/test/statement/import/050/test.volt
+++ b/rt/test/statement/import/050/test.volt
@@ -1,0 +1,10 @@
+//T macro:importfail
+//T check:multiple imports contain
+module test;
+
+import foo = [add1, add2];
+
+fn main() i32
+{
+    return (foo.add(1, 2) + foo.add("aa", "bbb")) - 8; 
+}

--- a/rt/test/statement/import/051/test.volt
+++ b/rt/test/statement/import/051/test.volt
@@ -1,0 +1,10 @@
+//T macro:importfail
+//T check:can't find module 'm34349'
+module test;
+
+import watt = [m1, m34349];
+
+fn main() i32
+{
+    return 0;
+}

--- a/rt/test/statement/import/deps/add1.volt
+++ b/rt/test/statement/import/deps/add1.volt
@@ -1,0 +1,6 @@
+module add1;
+
+fn add(a: i32, b: i32) i32
+{
+	return a + b;
+}

--- a/rt/test/statement/import/deps/add2.volt
+++ b/rt/test/statement/import/deps/add2.volt
@@ -1,0 +1,6 @@
+module add2;
+
+fn add(a: string, b: string) i32
+{
+	return cast(i32)a.length + cast(i32)b.length;
+}

--- a/rt/test/statement/import/deps/m14.volt
+++ b/rt/test/statement/import/deps/m14.volt
@@ -1,0 +1,5 @@
+module m14;
+
+global exportedVar: i32 = 32;
+global otherVar: i32 = 3232;
+global uniqueVar: i32 = 2;

--- a/src/volt/errors.d
+++ b/src/volt/errors.d
@@ -767,14 +767,14 @@ CompilerException makeSubclassFinal(ir.Class child, ir.Class parent, string file
 	return new CompilerError(child.loc, format("class '%s' attempts to subclass final class '%s'.", child.name, parent.name), file, line);
 }
 
-CompilerException makeCannotImport(ir.Node node, ir.Import _import, string file = __FILE__, const int line = __LINE__)
+CompilerException makeCannotImport(ir.Node node, string name, string file = __FILE__, const int line = __LINE__)
 {
-	return new CompilerError(node.loc, format("can't find module '%s'.", _import.name), file, line);
+	return new CompilerError(node.loc, format("can't find module '%s'.", name), file, line);
 }
 
-CompilerException makeCannotImportAnonymous(ir.Node node, ir.Import _import, string file = __FILE__, const int line = __LINE__)
+CompilerException makeCannotImportAnonymous(ir.Node node, string name, string file = __FILE__, const int line = __LINE__)
 {
-	return new CompilerError(node.loc, format("can't import anonymous module '%s'.", _import.name), file, line);
+	return new CompilerError(node.loc, format("can't import anonymous module '%s'.", name), file, line);
 }
 
 CompilerException makeNotAvailableInCTFE(ir.Node node, string s, string file = __FILE__, const int line = __LINE__)

--- a/src/volt/ir/context.d
+++ b/src/volt/ir/context.d
@@ -62,6 +62,7 @@ public:
 		Type,
 		Value,
 		Scope,
+		MultiScope,
 		Alias,
 		Merge,
 		Function,
@@ -97,6 +98,11 @@ public:
 	 * the exception being Scope, which does not have a owning node.
 	 */
 	Scope myScope;
+
+	/*!
+	 * The scope set for a MultiScope store.
+	 */
+	Scope[] scopes;
 
 	/*!
 	 * Overloaded functions.
@@ -396,6 +402,26 @@ public:
 		auto store = new Store(this, n, name, Store.Kind.Scope);
 		symbols[name] = store;
 		store.myScope = s;
+		store.importBindAccess = Access.Private;
+		return store;
+	}
+
+	/*!
+	 * Add a named multiscope, `n` is the node which introduced
+	 * this scope and must not be null.
+	 *
+	 * @Throws CompilerPanic if another symbol of the same name is found.
+	 */
+	Store addMultiScope(Node n, Scope[] s, string name)
+	in {
+		assert(n !is null);
+		assert(name !is null);
+	} body {
+		errorOn(n, name);
+
+		auto store = new Store(this, n, name, Store.Kind.MultiScope);
+		symbols[name] = store;
+		store.scopes = s;
 		store.importBindAccess = Access.Private;
 		return store;
 	}

--- a/src/volt/ir/toplevel.d
+++ b/src/volt/ir/toplevel.d
@@ -173,8 +173,8 @@ public:
 	//! Optional
 	bool isStatic;
 
-	//! import <a>
-	QualifiedName name;
+	//! import foo = <[a, b]>, or import [foo]
+	QualifiedName[] names;
 
 	//! Optional, import @<foo> = a
 	Identifier bind;
@@ -182,8 +182,8 @@ public:
 	//! Optional, import a : <b = c, d>
 	Identifier[][] aliases;
 
-	//! This points at the imported module -- filled in by ImportResolver.
-	Module targetModule;
+	//! These point at the imported modules -- filled in by ImportResolver.
+	Module[] targetModules;
 
 
 public:
@@ -194,13 +194,13 @@ public:
 		super(NodeType.Import, old);
 		this.access = old.access;
 		this.isStatic = old.isStatic;
-		this.name = old.name;
+		this.names = old.names.dup();
 		this.bind = old.bind;
 		this.aliases = old.aliases.dup();
 		foreach (i; 0 .. this.aliases.length) {
 			this.aliases[i] = old.aliases[i].dup();
 		}
-		this.targetModule = old.targetModule;
+		this.targetModules = old.targetModules.dup();
 	}
 }
 

--- a/src/volt/ir/util.d
+++ b/src/volt/ir/util.d
@@ -118,6 +118,8 @@ ir.Scope getScopeFromType(ir.Type type)
 ir.Scope getScopeFromStore(ir.Store store)
 {
 	final switch(store.kind) with (ir.Store.Kind) {
+	case MultiScope:
+		throw panic(store.node.loc, "getScopeFromStore called with MultiScope store.");
 	case Scope:
 		return store.myScope;
 	case Type:

--- a/src/volt/parser/base.d
+++ b/src/volt/parser/base.d
@@ -17,12 +17,7 @@ import volt.arg : Settings;
 public import volt.token.token : Token, TokenType, tokenToString;
 import volt.token.stream : TokenStream;
 import volt.token.location : Location;
-import volt.parser.errors : ParserError, ParserUnexpectedToken,
-                            ParserParseFailed, ParserUnsupportedFeature,
-                            ParserInvalidIntegerLiteral, ParserDocMultiple,
-                            ParserStrayDocComment, ParserWrongToken,
-                            ParserPanic, ParserAllArgumentsMustBeLabelled,
-                            ParserExpected, ParserNotAComposableString;
+import volt.parser.errors;
 
 
 /*
@@ -236,13 +231,19 @@ ParseStatus badComposable(ParserStream ps, Location loc,
 	return Failed;
 }
 
+ParseStatus badMultiBind(ParserStream ps, Location loc,
+						 string file = __FILE__, const int line = __LINE__)
+{
+	auto e = new ParserBadMultiBind(loc, file, line);
+	ps.parserErrors ~= e;
+	return Failed;
+}
 
 /*
  *
  * Stream checks helper functions.
  *
  */
-
 
 /*!
  * Match the current token on the parserstream @ps against @type.

--- a/src/volt/parser/errors.d
+++ b/src/volt/parser/errors.d
@@ -39,6 +39,8 @@ public:
 		StrayDocComment,
 		//! new "string without component"
 		BadComposableString,
+		//! Only bind imports can use multibind.
+		BadMultiBind,
 	}
 
 public:
@@ -274,5 +276,20 @@ public:
 	override string errorMessage()
 	{
 		return `expected a composable string component (${...}) in the string.`;
+	}
+}
+
+
+class ParserBadMultiBind : ParserError
+{
+public:
+	this(ref in Location loc, string file, const int line)
+	{
+		super(Kind.BadMultiBind, loc, NodeType.Invalid, file, line);
+	}
+
+	override string errorMessage()
+	{
+		return "multi import lists (`[foo, bar]`) may only be used in bind imports (`import baz = [foo, bar]`)";
 	}
 }

--- a/src/volt/parser/parser.d
+++ b/src/volt/parser/parser.d
@@ -15,7 +15,8 @@ import ir = volt.ir.ir;
 import volt.arg : Settings;
 import volt.errors : makeError, panic;
 import volt.interfaces : Frontend;
-import volt.parser.base : ParseStatus, ParserStream, ParserPanic, NodeSink;
+import volt.parser.base : ParseStatus, ParserStream, NodeSink;
+import volt.parser.errors : ParserPanic;
 import volt.parser.toplevel : parseModule;
 import volt.parser.statements : parseStatement;
 

--- a/src/volt/postparse/missing.d
+++ b/src/volt/postparse/missing.d
@@ -84,12 +84,12 @@ public:
 
 		if (i.isStatic && i.access != ir.Access.Private) {
 			throw makeExpected(i.loc, 
-				format("static import '%s' to be private", i.name));
+				format("static import '%s' to be private", i.names[0]));
 		}
 
-		auto mod = lp.getModule(i.name);
+		auto mod = lp.getModule(i.names[0]);
 		if (mod is null) {
-			mStore[i.name.toString()] = true;
+			mStore[i.names[0].toString()] = true;
 		}
 
 		return ContinueParent;

--- a/src/volt/semantic/extyper.d
+++ b/src/volt/semantic/extyper.d
@@ -135,7 +135,7 @@ ir.Type handleStore(Context ctx, string ident, ref ir.Exp exp, ir.Store store,
 	case Type:
 		return handleTypeStore(ctx, ident, exp, store, child, parent,
 		                       via);
-	case Scope:
+	case Scope, MultiScope:
 		return handleScopeStore(ctx, ident, exp, store, child, parent,
 		                        via);
 	case Value:
@@ -1166,7 +1166,7 @@ ir.Type consumeIdentsIfScopesOrTypes(Context ctx, ref ir.Postfix[] postfixes,
 
 	// Get a scope from said lookStore.
 	lookScope = lookStore.myScope;
-	assert(lookScope !is null);
+	assert(lookScope !is null || lookStore.scopes.length > 0);
 
 	// Loop over the identifiers.
 	foreach (i, postfix; postfixes) {
@@ -1184,7 +1184,12 @@ ir.Type consumeIdentsIfScopesOrTypes(Context ctx, ref ir.Postfix[] postfixes,
 		// Do the actual lookup.
 		assert(postfix.identifier !is null);
 		string name = postfix.identifier.value;
-		auto store = lookupAsImportScope(ctx.lp, lookScope, postfix.loc, name);
+		ir.Store store;
+		if (lookScope is null) {
+			store = lookupAsImportScopes(ctx.lp, lookStore.scopes, postfix.loc, name);
+		} else {
+			store = lookupAsImportScope(ctx.lp, lookScope, postfix.loc, name);
+		}
 		if (store is null) {
 			auto asEnum = cast(ir.Enum)lookType;
 			if (asEnum !is null && asEnum.name != "") {

--- a/src/volt/semantic/templatelifter.d
+++ b/src/volt/semantic/templatelifter.d
@@ -155,8 +155,9 @@ public:
 	ir.Import lift(ir.Import old)
 	{
 		auto n = new ir.Import(old);
-		if (old.targetModule !is null) {
-			n.targetModule = lift(old.targetModule);
+		n.targetModules = new ir.Module[](old.targetModules.length);
+		for (size_t i = 0; i < n.targetModules.length; ++i) {
+			n.targetModules[i] = lift(old.targetModules[i]);
 		}
 		return n;
 	}

--- a/src/volt/util/dup.d
+++ b/src/volt/util/dup.d
@@ -29,6 +29,7 @@ ir.Node[] dup(ir.Node[] arr) { return new arr[0 .. $]; }
 ir.Type[] dup(ir.Type[] arr) { return new arr[0 .. $]; }
 ir.Token[] dup(ir.Token[] arr) { return new arr[0 .. $]; }
 ir.AAPair[] dup(ir.AAPair[] arr) { return new arr[0 .. $]; }
+ir.Module[] dup(ir.Module[] arr) { return new arr[0 .. $]; }
 ir.Variable[] dup(ir.Variable[] arr) { return new arr[0 .. $]; }
 ir.Function[] dup(ir.Function[] arr) { return new arr[0 .. $]; }
 ir.Attribute[] dup(ir.Attribute[] arr) { return new arr[0 .. $]; }

--- a/src/volt/visitor/jsonprinter.d
+++ b/src/volt/visitor/jsonprinter.d
@@ -200,7 +200,18 @@ public:
 		tag("kind", "import");
 		tag("access", ir.accessToString(i.access));
 		tag("isStatic", i.isStatic);
-		tag("name", i.name.toString());
+		if (i.names.length == 1) {
+			tag("name", i.names[0].toString());
+		} else {
+			startList("names");
+			foreach (j, name; i.names) {
+				wq(name.toString());
+				if (j < i.names.length - 1) {
+					w(",\n");
+				}
+			}
+			endList();
+		}
 		if (i.bind !is null) {
 			tag("bind", i.bind.value);
 		}

--- a/src/volt/visitor/prettyprinter.d
+++ b/src/volt/visitor/prettyprinter.d
@@ -143,7 +143,18 @@ public:
 			accept(i.bind, this);
 			wf(" = ");
 		}
-		accept(i.name, this);
+		if (i.names.length == 1) {
+			accept(i.names[0], this);
+		} else {
+			wf("[");
+			foreach (idx, name; i.names) {
+				accept(name, this);
+				if (idx < i.names.length - 1) {
+					wf(", ");
+				}
+			}
+			wf("]");
+		}
 		if (i.aliases.length > 0) {
 			wf(" : ");
 			foreach (idx, _alias; i.aliases) {


### PR DESCRIPTION
Friends!

Have you ever wanted to bind multiple imports to a single conceptual name? For instance, putting all your `watt` imports under `watt`? Well, that has sadly been a pipe dream.

**UNTIL TODAY**

Introducing, M̶U̶L̶T̶I̶ ̶T̶R̶A̶C̶K̶ ̶D̶R̶I̶F̶T̶I̶N̶G̶ multibind imports, which allows you to do so.

    import watt = [watt.io, watt.conv];

That's the long and short of it really. A multibind isn't a valid overload set; any name duplication in the set will cause an error (on lookup of said name). 
