### PR TITLE
gc: Reduce stack usage when collecting.

### DIFF
--- a/rt/src/vrt/gc/arena.volt
+++ b/rt/src/vrt/gc/arena.volt
@@ -300,26 +300,28 @@ protected:
 	 */
 	fn pruneUsedSlabs(s: Slab*) Slab*
 	{
-		if (s is null) {
-			return null;
-		} else if (s.freeSlots == 0) {
-			// Is the next one still fully used?
-			s.next = pruneUsedSlabs(s.next);
-			// This is still fully used, return it.
-			return s;
-		} else if (s.usedSlots == 0) {
-			next := s.next;
-			s.next = null;
-			mManager.freeSlabStructAndMem(s);
-			// This was freed, return only next.
-			return pruneUsedSlabs(next);
-		} else {
-			next := s.next;
-			s.next = null;
-			pushFreeSlab(s);
-			// This slab turned into a free slab so return only next.
-			return pruneUsedSlabs(next);
+		currentSlab := s;
+		while (currentSlab !is null) {
+			if (currentSlab.freeSlots == 0) {
+				// Is the next one still fully used?
+				currentSlab.next = pruneUsedSlabs(currentSlab.next);
+				// This is still fully used, return it.
+				break;
+			} else if (currentSlab.usedSlots == 0) {
+				next := currentSlab.next;
+				currentSlab.next = null;
+				mManager.freeSlabStructAndMem(currentSlab);
+				// This was freed, return only next.
+				currentSlab = next;
+			} else {
+				next := currentSlab.next;
+				currentSlab.next = null;
+				pushFreeSlab(currentSlab);
+				// This slab turned into a free slab so return only next.
+				currentSlab = next;
+			}
 		}
+		return currentSlab;
 	}
 
 	fn free(ptr: void*)


### PR DESCRIPTION
While working on VLS I encountered an infinite loop situation fairly far down in the stack. While the infinite loop was a bug, it caused a crash in the GC due to a stack overflow, in particular `pruneUsedSlabs` was being called many many times. The function after this PR is still recursive, just less so.

Everything works over here (tm), but GC changes can be messy so I figured I would turn it into a PR rather than setting everything on fire as the last thing I did in my work week. So here we are.
