### PR TITLE
Implement templates for classes, unions, and interfaces.

### DIFF
--- a/lib/src/volta/ir/templates.d
+++ b/lib/src/volta/ir/templates.d
@@ -48,6 +48,9 @@ public:
 
 	Struct _struct;
 	Function _function;
+	Class _class;
+	Union _union;
+	_Interface _interface;
 
 public:
 	this()
@@ -67,6 +70,9 @@ public:
 		this.myScope = old.myScope;
 		this._struct = old._struct;
 		this._function = old._function;
+		this._class = old._class;
+		this._union = old._union;
+		this._interface = old._interface;
 		this.oldParent = old.oldParent;
 	}
 }

--- a/lib/src/volta/postparse/gatherer.d
+++ b/lib/src/volta/postparse/gatherer.d
@@ -692,16 +692,20 @@ public:
 
 	override Status enter(ir.Class c)
 	{
-		addScope(current, c, where, mErrSink);
-		gather(current, c, where, mErrSink);
+		if (c.myScope is null) {
+			addScope(current, c, where, mErrSink);
+			gather(current, c, where, mErrSink);
+		}
 		push(c.myScope, c);
 		return Continue;
 	}
 
 	override Status enter(ir._Interface i)
 	{
-		addScope(current, i, mErrSink);
-		gather(current, i, where, mErrSink);
+		if (i.myScope is null) {
+			addScope(current, i, mErrSink);
+			gather(current, i, where, mErrSink);
+		}
 		push(i.myScope, i);
 		return Continue;
 	}
@@ -718,8 +722,10 @@ public:
 
 	override Status enter(ir.Union u)
 	{
-		addScope(current, u, mErrSink);
-		gather(current, u, where, mErrSink);
+		if (u.myScope is null) {
+			addScope(current, u, mErrSink);
+			gather(current, u, where, mErrSink);
+		}
 		push(u.myScope, u);
 		return Continue;
 	}

--- a/lib/src/volta/visitor/visitor.d
+++ b/lib/src/volta/visitor/visitor.d
@@ -2337,6 +2337,12 @@ Visitor.Status acceptTemplateInstance(ir.TemplateInstance ti, Visitor av)
 		accept(ti._struct, av);
 	} else if (ti._function !is null) {
 		accept(ti._function, av);
+	} else if (ti._class !is null) {
+		accept(ti._class, av);
+	} else if (ti._union !is null) {
+		accept(ti._union, av);
+	} else if (ti._interface !is null) {
+		accept(ti._interface, av);
 	}
 
 	foreach (i, arg; ti.arguments) {

--- a/rt/test/template/007/test.volt
+++ b/rt/test/template/007/test.volt
@@ -1,5 +1,5 @@
 //T macro:expect-failure
-//T check:unsupported feature
+//T check:template definition is of type 'union'
 module test;
 
 union Struct!(T)

--- a/rt/test/template/abstractClassTemplate/test.volt
+++ b/rt/test/template/abstractClassTemplate/test.volt
@@ -1,0 +1,29 @@
+module test;
+
+abstract class Foo!(T)
+{
+	abstract fn get() T;
+
+	fn GET() T
+	{
+		return get() * 10;
+	}
+}
+
+class IntFoo = Foo!i32;
+
+class Bar!(T, C) : C
+{
+	override fn get() T
+	{
+		return 2;
+	}
+}
+
+class IntBar = Bar!(i32, IntFoo);
+
+fn main() i32
+{
+	ib := new IntBar();
+	return ib.GET() - ib.get() - 18;
+}

--- a/rt/test/template/abstractClassTemplateFail/test.volt
+++ b/rt/test/template/abstractClassTemplateFail/test.volt
@@ -1,0 +1,31 @@
+//T macro:expect-failure
+//T check:abstract classes like 'IntFoo'
+module test;
+
+abstract class Foo!(T)
+{
+	abstract fn get() T;
+
+	fn GET() T
+	{
+		return get() * 10;
+	}
+}
+
+class IntFoo = Foo!i32;
+
+class Bar!(T, C) : C
+{
+	override fn get() T
+	{
+		return 2;
+	}
+}
+
+class IntBar = Bar!(i32, IntFoo);
+
+fn main() i32
+{
+	ib := new IntFoo();
+	return ib.GET() - ib.get() - 18;
+}

--- a/rt/test/template/classMixin/test.volt
+++ b/rt/test/template/classMixin/test.volt
@@ -1,0 +1,16 @@
+//T macro:import
+module main;
+
+import contrived;
+
+enum V = 6;
+
+class MixinContrived   = mixin Contrived!i32;
+class RegularContrived =       Contrived!i32;
+
+fn main() i32
+{
+	a := new MixinContrived();
+	b := new RegularContrived();
+	return a.foo() + b.foo() - 18;
+}

--- a/rt/test/template/complexInterface/test.volt
+++ b/rt/test/template/complexInterface/test.volt
@@ -1,0 +1,71 @@
+module main;
+
+interface IStack!(T)
+{
+	@property fn length() size_t;
+	fn pop() i32;
+	fn push(T);
+}
+
+// Templated class implementing template.
+class SimpleStack!(T, I) : I
+{
+	array: T[];
+
+	override @property fn length() size_t
+	{
+		return array.length;
+	}
+
+	override fn pop() i32
+	{
+		v := array[$-1];
+		array = array[0 .. $-1];
+		// Traits expressions do in fact still exist.
+		static if (is(T == @isArray)) {
+			return cast(i32)v.length;
+		} else {
+			return v;
+		}
+	}
+
+	override fn push(val: T)
+	{
+		array ~= val;
+	}
+}
+
+interface IIntegerStack  = IStack!i32;
+interface IStringStack   = IStack!string;
+class SimpleIntegerStack = SimpleStack!(i32, IIntegerStack);
+class SimpleStringStack  = SimpleStack!(string, IStringStack);
+
+fn sumStack!(StackInterface)(stack: StackInterface) i32
+{
+	s: i32;
+	while (stack.length > 0) {
+		s += stack.pop();
+	}
+	return s;
+}
+
+// Overloading template instance taking templates.
+fn sum = sumStack!IIntegerStack;
+fn sum = sumStack!IStringStack;
+
+fn main() i32
+{
+	sis := new SimpleIntegerStack();
+	sis.push(5); sis.push(3); sis.push(-2); sis.push(12);
+	if (sum(sis) - 18 != 0) {
+		return 1;
+	}
+
+	sss := new SimpleStringStack();
+	sss.push("abc"); sss.push("cdef"); sss.push("g"); sss.push(null);
+	if (sum(sss) - 8 != 0) {
+		return 2;
+	}
+
+	return 0;
+}

--- a/rt/test/template/deps/contrived.volt
+++ b/rt/test/template/deps/contrived.volt
@@ -1,0 +1,11 @@
+module contrived;
+
+private enum V = 12;
+
+class Contrived!(T)
+{
+	fn foo() T
+	{
+		return V;
+	}
+}

--- a/rt/test/template/deps/eyeballs.volt
+++ b/rt/test/template/deps/eyeballs.volt
@@ -1,0 +1,8 @@
+module eyeballs;
+
+private enum V = 5;
+
+union Eyeballs!(T)
+{
+	global a: T = V;
+}

--- a/rt/test/template/inheritFromTemplate/test.volt
+++ b/rt/test/template/inheritFromTemplate/test.volt
@@ -1,0 +1,86 @@
+module main;
+
+class LinkedList!(T)
+{
+private:
+	mData: T;
+	mNext: LinkedList;
+
+public:
+	this()
+	{
+	}
+
+	this(val: T)
+	{
+		mData = val;
+	}
+
+public:
+	fn length() size_t
+	{
+		current := mNext;
+		count: size_t;
+		while (current !is null) {
+			count++;
+			current = current.mNext;
+		}
+		return count;
+	}
+
+	fn add(val: T)
+	{
+		if (mNext is null) {
+			mNext = new LinkedList(val);
+			return;
+		}
+		current := mNext;
+		while (current !is null) {
+			if (current.mNext is null) {
+				current.mNext = new LinkedList(val);
+				return;
+			}
+			current = current.mNext;
+		}
+	}
+
+	fn iterate(cb: scope dg(T))
+	{
+		current := mNext;
+		while (current !is null) {
+			cb(current.mData);
+			current = current.mNext;
+		}
+	}
+}
+
+class IntegerList = mixin LinkedList!i32;
+
+class AddOneList : IntegerList
+{
+public:
+	this() { super(); }
+	this(val: i32) { super(val); }
+
+public:
+	override fn add(val: i32)
+	{
+		super.add(val + 1);
+	}
+}
+
+fn main() i32
+{
+	checkVal := 1;
+	checkCounter := 0;
+	fn printInteger(val: i32) {if (checkVal++ == val) { checkCounter++; }}
+	il := new AddOneList();
+	il.add(0);
+	il.add(1);
+	il.add(2);
+	if (il.length() != 3) {
+		return 1;
+	}
+	il.iterate(printInteger);
+	return checkCounter - 3;
+}

--- a/rt/test/template/simpleClass/test.volt
+++ b/rt/test/template/simpleClass/test.volt
@@ -1,0 +1,73 @@
+module main;
+
+class LinkedList!(T)
+{
+private:
+	mData: T;
+	mNext: LinkedList;
+
+public:
+	this()
+	{
+	}
+
+	this(val: T)
+	{
+		mData = val;
+	}
+
+public:
+	fn length() size_t
+	{
+		current := mNext;
+		count: size_t;
+		while (current !is null) {
+			count++;
+			current = current.mNext;
+		}
+		return count;
+	}
+
+	fn add(val: T)
+	{
+		if (mNext is null) {
+			mNext = new LinkedList(val);
+			return;
+		}
+		current := mNext;
+		while (current !is null) {
+			if (current.mNext is null) {
+				current.mNext = new LinkedList(val);
+				return;
+			}
+			current = current.mNext;
+		}
+	}
+
+	fn iterate(cb: scope dg(T))
+	{
+		current := mNext;
+		while (current !is null) {
+			cb(current.mData);
+			current = current.mNext;
+		}
+	}
+}
+
+class IntegerList = LinkedList!i32;
+
+fn main() i32
+{
+	checkVal := 1;
+	checkCounter := 0;
+	fn printInteger(val: i32) {if (checkVal++ == val) { checkCounter++; }}
+	il := new IntegerList();
+	il.add(1);
+	il.add(2);
+	il.add(3);
+	if (il.length() != 3) {
+		return 1;
+	}
+	il.iterate(printInteger);
+	return checkCounter - 3;
+}

--- a/rt/test/template/simpleInterface/test.volt
+++ b/rt/test/template/simpleInterface/test.volt
@@ -1,0 +1,48 @@
+module main;
+
+interface IStack!(T)
+{
+	fn length() size_t;
+	fn pop() T;
+	fn push(T);
+}
+
+interface IIntegerStack = IStack!i32;
+
+class SimpleStack : IIntegerStack
+{
+	array: i32[];
+
+	override fn length() size_t
+	{
+		return array.length;
+	}
+
+	override fn pop() i32
+	{
+		v := array[$-1];
+		array = array[0 .. $-1];
+		return v;
+	}
+
+	override fn push(val: i32)
+	{
+		array ~= val;
+	}
+}
+
+fn sum(istack: IIntegerStack) i32
+{
+	sum: i32;
+	while (istack.length() > 0) {
+		sum += istack.pop();
+	}
+	return sum;
+}
+
+fn main() i32
+{
+	auto ss = new SimpleStack();
+	ss.push(5); ss.push(3); ss.push(-2); ss.push(12);
+	return sum(ss) - 18;
+}

--- a/rt/test/template/simpleUnion/test.volt
+++ b/rt/test/template/simpleUnion/test.volt
@@ -1,0 +1,23 @@
+//T macro:import
+module main;
+
+
+union UnionTemplate!(T, Y, U)
+{
+	a: T;
+	b: Y;
+	c: U;
+}
+
+union Edutainment = UnionTemplate!(i32, i64, i8);
+
+fn main() i32
+{
+	e: Edutainment;
+	e.b = 12;
+	if (e.a != 12 || e.b != 12 || e.c != 12 || typeid(Edutainment).size != typeid(i64).size) {
+		return 1;
+	}
+	e.c = 0;
+	return e.a;
+}

--- a/rt/test/template/templateInheritsFromNonTemplate/test.volt
+++ b/rt/test/template/templateInheritsFromNonTemplate/test.volt
@@ -1,0 +1,99 @@
+module main;
+
+class Foo
+{
+	fn foo() i32
+	{
+		return 6;
+	}
+}
+
+class LinkedList!(T) : Foo
+{
+private:
+	mData: T;
+	mNext: LinkedList;
+
+public:
+	this()
+	{
+	}
+
+	this(val: T)
+	{
+		mData = val;
+	}
+
+public:
+	fn length() size_t
+	{
+		current := mNext;
+		count: size_t;
+		while (current !is null) {
+			count++;
+			current = current.mNext;
+		}
+		return count;
+	}
+
+	fn add(val: T)
+	{
+		if (mNext is null) {
+			mNext = new LinkedList(val);
+			return;
+		}
+		current := mNext;
+		while (current !is null) {
+			if (current.mNext is null) {
+				current.mNext = new LinkedList(val);
+				return;
+			}
+			current = current.mNext;
+		}
+	}
+
+	fn iterate(cb: scope dg(T))
+	{
+		current := mNext;
+		while (current !is null) {
+			cb(current.mData);
+			current = current.mNext;
+		}
+	}
+}
+
+class IntegerList = mixin LinkedList!i32;
+
+class AddOneList : IntegerList
+{
+public:
+	this() { super(); }
+	this(val: i32) { super(val); }
+
+public:
+	override fn add(val: i32)
+	{
+		super.add(val + 1);
+	}
+
+	override fn foo() i32
+	{
+		return super.foo() * 2;
+	}
+}
+
+fn main() i32
+{
+	checkVal := 1;
+	checkCounter := 0;
+	fn printInteger(val: i32) {if (checkVal++ == val) { checkCounter++; }}
+	il := new AddOneList();
+	il.add(0);
+	il.add(1);
+	il.add(2);
+	if (il.length() != 3) {
+		return 1;
+	}
+	il.iterate(printInteger);
+	return checkCounter - 3 + (12 - il.foo());
+}

--- a/rt/test/template/templateInheritsFromTemplate/test.volt
+++ b/rt/test/template/templateInheritsFromTemplate/test.volt
@@ -1,0 +1,100 @@
+module main;
+
+class Foo!(T)
+{
+	fn foo() T
+	{
+		return 6;
+	}
+}
+
+class LinkedList!(T) : IntegerFoo
+{
+private:
+	mData: T;
+	mNext: LinkedList;
+
+public:
+	this()
+	{
+	}
+
+	this(val: T)
+	{
+		mData = val;
+	}
+
+public:
+	fn length() size_t
+	{
+		current := mNext;
+		count: size_t;
+		while (current !is null) {
+			count++;
+			current = current.mNext;
+		}
+		return count;
+	}
+
+	fn add(val: T)
+	{
+		if (mNext is null) {
+			mNext = new LinkedList(val);
+			return;
+		}
+		current := mNext;
+		while (current !is null) {
+			if (current.mNext is null) {
+				current.mNext = new LinkedList(val);
+				return;
+			}
+			current = current.mNext;
+		}
+	}
+
+	fn iterate(cb: scope dg(T))
+	{
+		current := mNext;
+		while (current !is null) {
+			cb(current.mData);
+			current = current.mNext;
+		}
+	}
+}
+
+class IntegerFoo  = Foo!i32;
+class IntegerList = LinkedList!i32;
+
+class AddOneList : IntegerList
+{
+public:
+	this() { super(); }
+	this(val: i32) { super(val); }
+
+public:
+	override fn add(val: i32)
+	{
+		super.add(val + 1);
+	}
+
+	override fn foo() i32
+	{
+		return super.foo() * 2;
+	}
+}
+
+fn main() i32
+{
+	checkVal := 1;
+	checkCounter := 0;
+	fn printInteger(val: i32) {if (checkVal++ == val) { checkCounter++; }}
+	il := new AddOneList();
+	il.add(0);
+	il.add(1);
+	il.add(2);
+	if (il.length() != 3) {
+		return 1;
+	}
+	il.iterate(printInteger);
+	return checkCounter - 3 + (12 - il.foo());
+}

--- a/rt/test/template/unionMixin/test.volt
+++ b/rt/test/template/unionMixin/test.volt
@@ -1,0 +1,14 @@
+//T macro:import
+module main;
+
+import eyeballs;
+
+enum V = 7;
+
+union IntegerEyeballsA =       Eyeballs!i32;
+union IntegerEyeballsB = mixin Eyeballs!i32;
+
+fn main() i32
+{
+	return IntegerEyeballsA.a + IntegerEyeballsB.a - 12;
+}

--- a/src/volt/errors.d
+++ b/src/volt/errors.d
@@ -61,6 +61,14 @@ CompilerException makeEmitLLVMNoLink(string file = __FILE__, const int line = __
  *
  */
 
+CompilerException makeMismatchedTemplateInstanceAndDefinition(ref in Location loc, ir.TemplateKind instanceKind,
+	ir.TemplateKind definitionKind, string file = __FILE__, const int line = __LINE__)
+{
+	string msg = format("template definition is of type '%s', but instance is of type '%s'.",
+		templateKindString(definitionKind), templateKindString(instanceKind));
+	return makeError(/*#ref*/loc, msg, file, line);
+}
+
 CompilerException makeRangeForeachWithIndex(ref in Location loc,
 	string file = __FILE__, const int line = __LINE__)
 {
@@ -1092,6 +1100,17 @@ void panicAssert(ref in Location loc, bool condition, string file = __FILE__, co
 
 
 private:
+
+string templateKindString(ir.TemplateKind kind)
+{
+	final switch (kind) with (ir.TemplateKind) {
+	case Struct:    return "struct";
+	case Class:     return "class";
+	case Union:     return "union";
+	case Interface: return "interface";
+	case Function:  return "function";
+	}
+}
 
 string typeString(ir.Type t)
 {

--- a/src/volt/semantic/classresolver.d
+++ b/src/volt/semantic/classresolver.d
@@ -134,9 +134,15 @@ ir.Type rewriteSuper(Context ctx, ref ir.Exp e, ir.IdentifierExp ident,
 
 ir.Type rewriteSuperIdentifier(ref ir.Exp e, ir.Class _class)
 {
+	auto lookupScope = _class.myScope.parent;
+	if (lookupScope.node.nodeType == ir.NodeType.TemplateInstance) {
+		lookupScope = lookupScope.parent;
+	}
+	assert(lookupScope !is null);
+
 	// No better way of doing this. :-(
 	// Also assumes that the class has a valid scope.
-	auto store = _class.myScope.parent.getStore(_class.name);
+	auto store = lookupScope.getStore(_class.name);
 	assert(store !is null);
 	assert(store.node is _class);
 

--- a/src/volt/semantic/extyper.d
+++ b/src/volt/semantic/extyper.d
@@ -3448,16 +3448,6 @@ void extypeThrowStatement(Context ctx, ref ir.Node n)
 	}
 }
 
-/*!
- * Just check that it's a struct template for now.
- */
-void extypeTemplateDefinition(Context ctx, ir.TemplateDefinition td)
-{
-	if (td._struct is null && td._function is null) {
-		throw makeUnsupported(/*#ref*/td.loc, "non struct/function template definitions");
-	}
-}
-
 void extypeTemplateInstance(Context ctx, ir.TemplateInstance ti)
 {
 	auto tlifter = new TemplateLifter();
@@ -5585,15 +5575,21 @@ public:
 		ctx.enter(ti);
 		if (ti._struct is null && ti._function is null) {
 			extypeTemplateInstance(ctx, ti);
-			switch (ti.kind) with (ir.TemplateKind) {
+			final switch (ti.kind) with (ir.TemplateKind) {
 			case Struct:
 				accept(ti._struct, ctx.extyper);
 				break;
 			case Function:
 				accept(ti._function, ctx.extyper);
 				break;
-			default:
-				panicAssert(ti, false);
+			case Class:
+				accept(ti._class, ctx.extyper);
+				break;
+			case Union:
+				accept(ti._union, ctx.extyper);
+				break;
+			case Interface:
+				accept(ti._interface, ctx.extyper);
 				break;
 			}
 		}
@@ -5604,12 +5600,6 @@ public:
 	{
 		ctx.leave(ti);
 		ti.myScope.parent = ti.oldParent;
-		return Continue;
-	}
-
-	override Status visit(ir.TemplateDefinition td)
-	{
-		extypeTemplateDefinition(ctx, td);
 		return Continue;
 	}
 


### PR DESCRIPTION
These commits implement the remaining planned template types. Namely, classes, unions, and interfaces. In addition, approximately a dozen new tests have been added for these kinds of templates.

The implementation is fairly straight forward. What was `templateLiftStruct` has become `templateLiftAggregate` and handles all the new templates, which means the amount of new code is relatively low.

Attention, perhaps, should be drawn to the changes at the top of `rewriteSuperIdentifier` at `classresolver.d:135`.

```volt
ir.Type rewriteSuperIdentifier(ref ir.Exp e, ir.Class _class)
{
	auto lookupScope = _class.myScope.parent;
	if (lookupScope.node.nodeType == ir.NodeType.TemplateInstance) {
		lookupScope = lookupScope.parent;
	}
	assert(lookupScope !is null);
```


If unfamiliar this code gets the `Store` for the parent class by looking above its scope. This is already not a super clean solution (although it's relatively small and innocuous as such things go) as noted by the pre-existing comment. Because in the case of `TemplateInstance`s, the scope that contains the template parameters etc will be above the instance's scope, and not the top level scope it's been instantiated in, this just bumps it up one scope.

I didn't think this justified a major refactoring, as it's fairly contained, but I figured I would bring it up.

---

Finally, attention should be brought to [this commit over on the Docs repository](https://github.com/VoltLang/Docs/commit/c5bd6d63b08dd972bb52e38a08d03746668c5a51). This updates the TVPL documentation to note that one can use templates for classes, interfaces, and unions in much the same manner as the detailed struct instructions. I didn't think it worth going into more detail than that, as as far as template features go, there's no differences between them.