### PR TITLE
Add T.default syntax

### DIFF
--- a/lib/src/volta/interfaces.d
+++ b/lib/src/volta/interfaces.d
@@ -149,9 +149,12 @@ interface Frontend
 	 * @param[in] tokens The list of tokens that comprise the body of the
 	 *                   function. Starts with BEGIN {, and ends with
 	 *                   } END tokens.
+	 * @param[in] magicFlagD Whether the tokens should use legacy parsing
+	 *                       functionality, as if they had the magic D flag
+	 *                       on top.
 	 * @return The parsed BlockStatement.
 	 */
-	ir.BlockStatement parseBlockStatement(ref ir.Token[] tokens);
+	ir.BlockStatement parseBlockStatement(ref ir.Token[] tokens, bool magicFlagD);
 
 	/*!
 	 * Parse a zero or more statements from a string, does not

--- a/lib/src/volta/ir/expression.d
+++ b/lib/src/volta/ir/expression.d
@@ -316,6 +316,7 @@ public:
 		Index,
 		Slice,
 		CreateDelegate,
+		Default,  //!< T.default -- default initialiser of T
 	}
 
 	enum TagKind
@@ -337,6 +338,7 @@ public:
 		case Op.Index: return "index";
 		case Op.Slice: return "slice";
 		case Op.CreateDelegate: return "createdelegate";
+		case Op.Default: return "default";
 		}
 	}
 

--- a/lib/src/volta/parser/expression.d
+++ b/lib/src/volta/parser/expression.d
@@ -1449,6 +1449,15 @@ ParseStatus parsePostfixExp(ParserStream ps, out intir.PostfixExp exp, bool disa
 	switch (ps.peek.type) {
 	case TokenType.Dot:
 		ps.get();
+		if (matchIf(ps, TokenType.Default)) {
+			exp.op = ir.Postfix.Op.Default;
+			auto succeeded = parsePostfixExp(ps, /*#out*/exp.postfix, disableNoDoubleDotSlice, depth);
+			if (!succeeded) {
+				return parseFailed(ps, ir.NodeType.Postfix);
+			}
+			break;
+		}
+
 		bool eof;
 		auto twoAhead = ps.lookahead(2, /*#out*/eof).type;
 		if (ps.lookahead(1, /*#out*/eof).type == TokenType.Bang &&
@@ -1775,6 +1784,8 @@ ParseStatus parsePrimaryExp(ParserStream ps, out intir.PrimaryExp exp)
 			}
 			if (matchIf(ps, TokenType.Typeid)) {
 				exp.op = intir.PrimaryExp.Type.Typeid;
+			} else if (matchIf(ps, TokenType.Default) && !ps.magicFlagD) {
+				exp._string = "default";
 			} else {
 				Token nameTok;
 				succeeded = match(ps, ir.NodeType.TypeExp, TokenType.Identifier, /*#out*/nameTok);
@@ -1831,6 +1842,8 @@ ParseStatus parsePrimaryExp(ParserStream ps, out intir.PrimaryExp exp)
 		}
 		if (matchIf(ps, TokenType.Typeid)) {
 			exp.op = intir.PrimaryExp.Type.Typeid;
+		} else if (matchIf(ps, TokenType.Default) && !ps.magicFlagD) {
+			exp._string = "default";
 		} else {
 			Token nameTok;
 			succeeded = match(ps, ir.NodeType.Constant, TokenType.Identifier, /*#out*/nameTok);

--- a/lib/src/volta/parser/parser.d
+++ b/lib/src/volta/parser/parser.d
@@ -87,9 +87,10 @@ public:
 		return mod;
 	}
 
-	override ir.BlockStatement parseBlockStatement(ref ir.Token[] tokens)
+	override ir.BlockStatement parseBlockStatement(ref ir.Token[] tokens, bool magicFlagD)
 	{
 		auto parserStream = new ParserStream(tokens, settings, errSink);
+		parserStream.magicFlagD = magicFlagD;
 		ir.BlockStatement blockStatement;
 		auto parserStatus = parseBlock(parserStream, /*#out*/blockStatement);
 		checkError(parserStream, parserStatus);

--- a/rt/src/vrt/vacuum/aa.volt
+++ b/rt/src/vrt/vacuum/aa.volt
@@ -59,7 +59,7 @@ public:
 
 	/*!
 	 * Simpler helper for getting values,
-	 * returns `Value.init` if the key was not found.
+	 * returns `Value.default` if the key was not found.
 	 */
 	fn getOrInit(key: Key) Value
 	{
@@ -304,8 +304,8 @@ public:
 	fn clearAt(index: size_t)
 	{
 		mDistances.ptr[index] = 0;
-		mValues.ptr[index] = Value.init;
-		mKeys.ptr[index] = Key.init;
+		mValues.ptr[index] = Value.default;
+		mKeys.ptr[index] = Key.default;
 	}
 
 
@@ -386,7 +386,7 @@ public:
 
 	/*!
 	 * Simpler helper for getting values,
-	 * returns `Value.init` if the key was not found.
+	 * returns `Value.default` if the key was not found.
 	 */
 	fn getOrInit(key: Key) Value
 	{
@@ -646,8 +646,8 @@ public:
 	fn clearAt(index: size_t)
 	{
 		mDistances.ptr[index] = 0;
-		mValues.ptr[index] = Value.init;
-		mKeys.ptr[index] = null; // @todo Key.init;
+		mValues.ptr[index] = Value.default;
+		mKeys.ptr[index] = null; // @todo Key.default;
 	}
 
 

--- a/rt/test/bugs/declaration/027/test.volt
+++ b/rt/test/bugs/declaration/027/test.volt
@@ -20,7 +20,7 @@ fn main() i32
 {
 	my: My;
 	my.foo = 42;
-	my = My.init;
+	my = My.default;
 
 	return my.foo;
 }

--- a/rt/test/bugs/expression/029/test.volt
+++ b/rt/test/bugs/expression/029/test.volt
@@ -2,6 +2,6 @@ module test;
 
 fn main() i32
 {
-	foo := dchar.init;
+	foo := dchar.default;
 	return cast(i32)foo;
 }

--- a/rt/test/errors/038/test.volt
+++ b/rt/test/errors/038/test.volt
@@ -1,5 +1,3 @@
-//T macro:expect-failure
-//T check:functions may not be named 'init'
 module test;
 
 fn init(x: i32)

--- a/rt/test/errors/039/test.volt
+++ b/rt/test/errors/039/test.volt
@@ -1,5 +1,3 @@
-//T macro:expect-failure
-//T check:static field 'init' collides
 module test;
 
 struct S

--- a/rt/test/expression/literal/unionInit/test.volt
+++ b/rt/test/expression/literal/unionInit/test.volt
@@ -15,6 +15,6 @@ fn main() i32
 	s: S;
 	s.x = 1;
 	s.u.y = 12;
-	s = S.init;
+	s = S.default;
 	return cast(i32)(s.x + s.u.y + s.u.z);
 }

--- a/rt/test/expression/postfix/009/test.volt
+++ b/rt/test/expression/postfix/009/test.volt
@@ -8,6 +8,6 @@ fn main() i32
 {
 	s: S;
 	s.x = 32;
-	s = S.init;
+	s = S.default;
 	return s.x;
 }

--- a/rt/test/expression/postfix/010/test.volt
+++ b/rt/test/expression/postfix/010/test.volt
@@ -4,6 +4,6 @@ import core.object : Object;
 
 fn main() i32
 {
-	obj := Object.init;
+	obj := Object.default;
 	return obj is null ? 0 : 27;
 }

--- a/rt/test/expression/postfix/tdefault/nontype/test.volt
+++ b/rt/test/expression/postfix/tdefault/nontype/test.volt
@@ -1,0 +1,11 @@
+//T macro:expect-failure
+//T check:.default on non-type expression
+module test;
+
+alias A = i32;
+
+fn main() i32
+{
+	a: A;
+	return a.default;
+}

--- a/rt/test/expression/postfix/tdefault/simpleFailure/test.volt
+++ b/rt/test/expression/postfix/tdefault/simpleFailure/test.volt
@@ -1,0 +1,14 @@
+//T macro:expect-failure
+//T check:unidentified identifier 'init'
+module test;
+
+struct S
+{
+	x: i32;
+}
+
+fn main() i32
+{
+	s := S.init;
+	return s.x;
+}

--- a/rt/test/expression/postfix/tdefault/simpleWorking/test.volt
+++ b/rt/test/expression/postfix/tdefault/simpleWorking/test.volt
@@ -1,0 +1,12 @@
+module test;
+
+struct S
+{
+	x: i32;
+}
+
+fn main() i32
+{
+	s := S.default;
+	return S.default.x + i32.default;
+}

--- a/rt/test/expression/type/001/test.volt
+++ b/rt/test/expression/type/001/test.volt
@@ -5,6 +5,6 @@ alias IntArray = i32[];
 fn main() i32
 {
 	y := [1, 2, 3];
-	y = IntArray.init;
+	y = IntArray.default;
 	return cast(i32)y.length;
 }

--- a/rt/test/expression/type/002/test.volt
+++ b/rt/test/expression/type/002/test.volt
@@ -3,6 +3,6 @@ module test;
 fn main() i32
 {
 	y := [1, 2, 3];
-	y = (i32[]).init;
+	y = (i32[]).default;
 	return cast(i32)y.length;
 }

--- a/rt/test/expression/type/003/test.volt
+++ b/rt/test/expression/type/003/test.volt
@@ -6,6 +6,6 @@ fn main() i32
 {
 	i: i32;
 	p := &i;
-	p = IntPointer.init;
+	p = IntPointer.default;
 	return cast(i32)p;
 }

--- a/rt/test/expression/type/004/test.volt
+++ b/rt/test/expression/type/004/test.volt
@@ -4,6 +4,6 @@ fn main() i32
 {
 	i: i32;
 	p := &i;
-	p = (i32*).init;
+	p = (i32*).default;
 	return cast(i32)p;
 }

--- a/src/volt/errors.d
+++ b/src/volt/errors.d
@@ -61,10 +61,16 @@ CompilerException makeEmitLLVMNoLink(string file = __FILE__, const int line = __
  *
  */
 
+CompilerException makeDefaultOnExpression(ref in Location loc,
+	string file = __FILE__, const int line = __LINE__)
+{
+	return makeError(/*#ref*/loc, ".default on non-type expression.", file, line);
+}
+
 CompilerException makeCannotCastPointerToDelegate(ref in Location loc,
 	string file = __FILE__, const int line = __LINE__)
 {
-	return makeError(/*#ref*/loc, "cannot cast a delegate to a pointer.");
+	return makeError(/*#ref*/loc, "cannot cast a delegate to a pointer.", file, line);
 }
 
 CompilerException makeMismatchedTemplateInstanceAndDefinition(ref in Location loc, ir.TemplateKind instanceKind,


### PR DESCRIPTION
Per our earlier discussion, this commit adds the syntax

```
T.default
```
To get the default initialiser for a given type, T. This replaces the old `T.init` syntax (except in magicD modules), and removes the restrictions on naming fields and functions 'init'. There's a matching Watt PR needed for compilation.
